### PR TITLE
Rename METSWriter to METS

### DIFF
--- a/metsrw/fsentry.py
+++ b/metsrw/fsentry.py
@@ -18,7 +18,7 @@ class FSEntry(object):
     """
     A class representing a filesystem entry - either a file or a directory.
 
-    When passed to a METSWriter instance, the tree of FSEntry objects will
+    When passed to a :class:`metsrw.mets.METSDocument` instance, the tree of FSEntry objects will
     be used to construct the <fileSec> and <structMap> elements of a
     METS document.
 

--- a/metsrw/metadata.py
+++ b/metsrw/metadata.py
@@ -20,7 +20,7 @@ class AMDSec(object):
     An object representing a section of administrative metadata in a
     document.
 
-    This is ordinarily created by METSWriter instances and does not
+    This is ordinarily created by :class:`metsrw.mets.METSDocument` instances and does not
     have to be instantiated directly.
 
     :param str section_id: ID of the section. If not provided, will be generated from 'amdSec' and a random number.

--- a/metsrw/mets.py
+++ b/metsrw/mets.py
@@ -14,7 +14,7 @@ from . import utils
 LOGGER = logging.getLogger(__name__)
 
 
-class METSWriter(object):
+class METSDocument(object):
     def __init__(self):
         # Stores the ElementTree if this was parsed from an existing file
         self.tree = None
@@ -46,9 +46,9 @@ class METSWriter(object):
 
     def all_files(self):
         """
-        Return a set of all FSEntrys in this METSWriter.
+        Return a set of all FSEntrys in this METS document.
 
-        :returns: Set containing all :class:`FSEntry` in this METSWriter,
+        :returns: Set containing all :class:`FSEntry` in this METS document,
             including descendants of ones explicitly added.
         """
         # NOTE: Cannot use _collect_files_uuid and .values() because not all
@@ -92,7 +92,7 @@ class METSWriter(object):
         A given FSEntry object can only be included in a document once,
         and any attempt to add an object the second time will be ignored.
 
-        :param FSEntry fs_entry: FSEntry to add to the METS file
+        :param FSEntry fs_entry: FSEntry to add to the METS document
         """
 
         if fs_entry in self._root_elements:
@@ -138,7 +138,7 @@ class METSWriter(object):
         Return all dmdSec and amdSec classes associated with the files.
 
         Returns all dmdSecs, then all amdSecs, so they only need to be
-        serialized before being appended to the METS.
+        serialized before being appended to the METS document.
 
         :param List files: List of :class:`FSEntry` to collect MDSecs for.
         :returns: List of AMDSecs and SubSections
@@ -211,7 +211,7 @@ class METSWriter(object):
 
     def tostring(self, fully_qualified=True, pretty_print=True):
         """
-        Serialize and return a string of this METS file.
+        Serialize and return a string of this METS document.
 
         To write to file, see :meth:`write`
 
@@ -222,9 +222,9 @@ class METSWriter(object):
 
     def write(self, filepath, fully_qualified=True, pretty_print=False):
         """
-        Serialize and write this METS file to `filepath`.
+        Serialize and write this METS document to `filepath`.
 
-        :param str filepath: Path to write the METS to
+        :param str filepath: Path to write the METS document to
         """
         root = self.serialize(fully_qualified=fully_qualified)
         tree = root.getroottree()
@@ -315,9 +315,9 @@ class METSWriter(object):
 
     def fromfile(self, path):
         """
-        Accept a filepath pointing to a valid METS file and parses it.
+        Accept a filepath pointing to a valid METS document and parses it.
 
-        :param str path: Path to a METS file.
+        :param str path: Path to a METS document.
         """
         parser = etree.XMLParser(remove_blank_text=True)
         self.tree = etree.parse(path, parser=parser)
@@ -327,7 +327,7 @@ class METSWriter(object):
         """
         Accept a string containing valid METS xml and parses it.
 
-        :param str string: String containing a METS file.
+        :param str string: String containing a METS document.
         """
         parser = etree.XMLParser(remove_blank_text=True)
         root = etree.fromstring(string, parser)
@@ -338,13 +338,13 @@ class METSWriter(object):
         """
         Accept an ElementTree or Element and parses it.
 
-        :param ElementTree tree: ElementTree to build a METS file from.
+        :param ElementTree tree: ElementTree to build a METS document from.
         """
         self.tree = tree
         self._parse_tree(self.tree)
 
 
 if __name__ == '__main__':
-    mw = METSWriter()
+    mw = METSDocument()
     mw.fromfile(sys.argv[1])
     mw.write(sys.argv[2], fully_qualified=True, pretty_print=True)

--- a/tests/test_mets.py
+++ b/tests/test_mets.py
@@ -7,11 +7,11 @@ import uuid
 
 import metsrw
 
-class TestMETSWriter(TestCase):
-    """ Test METSWriter class. """
+class TestMETSDocument(TestCase):
+    """ Test METSDocument class. """
 
     def test_fromfile(self):
-        mw = metsrw.METSWriter()
+        mw = metsrw.METSDocument()
         parser = etree.XMLParser(remove_blank_text=True)
         root = etree.parse('fixtures/complete_mets.xml', parser=parser)
         mw.fromfile('fixtures/complete_mets.xml')
@@ -19,7 +19,7 @@ class TestMETSWriter(TestCase):
         assert etree.tostring(mw.tree) == etree.tostring(root)
 
     def test_fromstring(self):
-        mw = metsrw.METSWriter()
+        mw = metsrw.METSDocument()
         parser = etree.XMLParser(remove_blank_text=True)
         root = etree.parse('fixtures/complete_mets.xml', parser=parser)
         with open('fixtures/complete_mets.xml', 'rb') as f:
@@ -29,14 +29,14 @@ class TestMETSWriter(TestCase):
         assert etree.tostring(mw.tree) == etree.tostring(root)
 
     def test_fromtree(self):
-        mw = metsrw.METSWriter()
+        mw = metsrw.METSDocument()
         root = etree.parse('fixtures/complete_mets.xml')
         mw.fromtree(root)
         assert isinstance(mw.tree, etree._ElementTree)
         assert etree.tostring(mw.tree) == etree.tostring(root)
 
     def test_parse_tree(self):
-        mw = metsrw.METSWriter()
+        mw = metsrw.METSDocument()
         parser = etree.XMLParser(remove_blank_text=True)
         root = etree.parse('fixtures/complete_mets.xml', parser=parser)
         mw.tree = root
@@ -44,14 +44,14 @@ class TestMETSWriter(TestCase):
         assert mw.createdate == '2014-07-23T21:48:33'
 
     def test_parse_tree_createdate_too_new(self):
-        mw = metsrw.METSWriter()
+        mw = metsrw.METSDocument()
         root = etree.parse('fixtures/createdate_too_new.xml')
         mw.tree = root
         with pytest.raises(metsrw.ParseError):
             mw._parse_tree()
 
     def test_write(self):
-        mw = metsrw.METSWriter()
+        mw = metsrw.METSDocument()
         # mock serialize
         parser = etree.XMLParser(remove_blank_text=True)
         root = etree.parse('fixtures/complete_mets.xml', parser=parser).getroot()
@@ -61,7 +61,7 @@ class TestMETSWriter(TestCase):
         os.remove('test_write.xml')
 
     def test_mets_root(self):
-        mw = metsrw.METSWriter()
+        mw = metsrw.METSDocument()
         root = mw._document_root()
         location = "http://www.loc.gov/METS/ " + \
             "http://www.loc.gov/standards/mets/version18/mets.xsd"
@@ -75,14 +75,14 @@ class TestMETSWriter(TestCase):
         assert root.nsmap == nsmap
 
     def test_mets_header(self):
-        mw = metsrw.METSWriter()
+        mw = metsrw.METSDocument()
         date = '2014-07-16T22:52:02.480108'
         header = mw._mets_header(date)
         assert header.tag == '{http://www.loc.gov/METS/}metsHdr'
         assert header.attrib['CREATEDATE'] == date
 
     def test_mets_header_lastmoddate(self):
-        mw = metsrw.METSWriter()
+        mw = metsrw.METSDocument()
         date = '2014-07-16T22:52:02.480108'
         new_date = '3014-07-16T22:52:02.480108'
         mw.createdate = date
@@ -104,7 +104,7 @@ class TestWholeMETS(TestCase):
         d1 = metsrw.FSEntry('dir1', type='Directory', children=[d2, f2])
         f1 = metsrw.FSEntry('level1.txt', file_uuid=str(uuid.uuid4()))
         d = metsrw.FSEntry('root', type='Directory', children=[d1, f1])
-        mw = metsrw.METSWriter()
+        mw = metsrw.METSDocument()
         mw.append_file(d)
         files = mw.all_files()
         assert files
@@ -133,7 +133,7 @@ class TestWholeMETS(TestCase):
         f1_uuid = str(uuid.uuid4())
         f1 = metsrw.FSEntry('level1.txt', file_uuid=f1_uuid)
         d = metsrw.FSEntry('root', type='Directory', children=[d1, f1])
-        mw = metsrw.METSWriter()
+        mw = metsrw.METSDocument()
         mw.append_file(d)
         assert mw.get_file(f3_uuid) == f3
         assert mw.get_file(f2_uuid) == f2
@@ -150,7 +150,7 @@ class TestWholeMETS(TestCase):
         f1.dmdsecs.append(metsrw.SubSection('dmdSec', None))
         f2 = metsrw.FSEntry('file2.txt', file_uuid=str(uuid.uuid4()))
         f2.dmdsecs.append(metsrw.SubSection('dmdSec', None))
-        mw = metsrw.METSWriter()
+        mw = metsrw.METSDocument()
         elements = mw._collect_mdsec_elements([f1, f2])
         # Check ordering - dmdSec before amdSec
         assert isinstance(elements, list)
@@ -165,7 +165,7 @@ class TestWholeMETS(TestCase):
         o = metsrw.FSEntry('objects/file1.txt', file_uuid=str(uuid.uuid4()))
         p = metsrw.FSEntry('objects/file1-preservation.txt', use='preservaton', file_uuid=str(uuid.uuid4()))
         o2 = metsrw.FSEntry('objects/file2.txt', file_uuid=str(uuid.uuid4()))
-        mw = metsrw.METSWriter()
+        mw = metsrw.METSDocument()
         element = mw._filesec([o, p, o2])
         assert isinstance(element, etree._Element)
         assert element.tag == '{http://www.loc.gov/METS/}fileSec'
@@ -182,7 +182,7 @@ class TestWholeMETS(TestCase):
             metsrw.FSEntry('objects/file2.txt', file_uuid=str(uuid.uuid4())),
         ]
         parent = metsrw.FSEntry('objects', type='Directory', children=children)
-        writer = metsrw.METSWriter()
+        writer = metsrw.METSDocument()
         writer.append_file(parent)
         sm = writer._structmap()
 
@@ -201,7 +201,7 @@ class TestWholeMETS(TestCase):
         assert children[1].find('{http://www.loc.gov/METS/}fptr') is not None
 
     def test_full_mets(self):
-        mw = metsrw.METSWriter()
+        mw = metsrw.METSDocument()
         file1 = metsrw.FSEntry('objects/object1.ext', file_uuid=str(uuid.uuid4()))
         file2 = metsrw.FSEntry('objects/object2.ext', file_uuid=str(uuid.uuid4()))
         file1p = metsrw.FSEntry('objects/object1-preservation.ext', use='preservation', file_uuid=str(uuid.uuid4()), derived_from=file1)


### PR DESCRIPTION
Rename METSWriter class to METS.

* + Does more than writing (also parses a METS)
* + Reflects what you're actually creating (a METS file)
* - Calling main class METS is too generic and hard to easily grep for (false positives with METS as standard)

Thoughts?