### PR TITLE
FSEntry updates: IDs, children/parents, str

### DIFF
--- a/metsrw/fsentry.py
+++ b/metsrw/fsentry.py
@@ -91,6 +91,8 @@ class FSEntry(object):
         if type != 'Directory' and children:
             raise ValueError("Only directory objects can have children")
 
+    # PROPERTIES
+
     def _create_id(self, prefix):
         return prefix + '_' + str(randint(1, 999999))
 
@@ -114,13 +116,17 @@ class FSEntry(object):
             return None
         return utils.GROUP_ID_PREFIX + self.file_uuid
 
+    @property
     def admids(self):
         """ Returns a list of ADMIDs for this entry. """
         return [a.id_string() for a in self.amdsecs]
 
+    @property
     def dmdids(self):
         """ Returns a list of DMDIDs for this entry. """
         return [d.id_string() for d in self.dmdsecs]
+
+    # ADD ATTRIBUTES
 
     def _add_metadata_element(self, md, subsection, mdtype, mode='mdwrap', **kwargs):
         """
@@ -206,8 +212,8 @@ class FSEntry(object):
         el = etree.Element(utils.lxmlns('mets') + 'file', ID=self.file_id())
         if self.group_id():
             el.attrib['GROUPID'] = self.group_id()
-        if self.admids():
-            el.set('ADMID', ' '.join(self.admids()))
+        if self.admids:
+            el.set('ADMID', ' '.join(self.admids))
         if self.checksum and self.checksumtype:
             el.attrib['CHECKSUM'] = self.checksum
             el.attrib['CHECKSUMTYPE'] = self.checksumtype
@@ -232,8 +238,8 @@ class FSEntry(object):
         el = etree.Element(utils.lxmlns('mets') + 'div', TYPE=self.type, LABEL=self.label)
         if self.file_id():
             etree.SubElement(el, utils.lxmlns('mets') + 'fptr', FILEID=self.file_id())
-        if self.dmdids():
-            el.set('DMDID', ' '.join(self.dmdids()))
+        if self.dmdids:
+            el.set('DMDID', ' '.join(self.dmdids))
 
         if recurse and self.children:
             for child in self.children:

--- a/metsrw/fsentry.py
+++ b/metsrw/fsentry.py
@@ -90,6 +90,11 @@ class FSEntry(object):
         self.amdsecs = []
         self.dmdsecs = []
 
+    def __str__(self):
+        return '{s.type}: {s.path}'.format(s=self)
+
+    def __repr__(self):
+        return 'FSEntry(type={s.type!r}, path={s.path!r}, use={s.use!r}, label={s.label!r}, file_uuid={s.file_uuid!r}, checksum={s.checksum!r}, checksumtype={s.checksumtype!r})'.format(s=self)
 
     # PROPERTIES
 

--- a/metsrw/mets.py
+++ b/metsrw/mets.py
@@ -244,11 +244,7 @@ class METSDocument(object):
             entry_type = elem.get('TYPE')
             label = elem.get('LABEL')
             fptr = elem.find('mets:fptr', namespaces=utils.NAMESPACES)
-            file_uuid = None
-            derived_from = None
-            use = None
-            path = None
-            amdids = None
+            file_uuid = derived_from = use = path = amdids = checksum = checksumtype = None
             if fptr is not None:
                 file_id = fptr.get('FILEID')
                 file_elem = tree.find('mets:fileSec//mets:file[@ID="' + file_id + '"]', namespaces=utils.NAMESPACES)
@@ -261,12 +257,14 @@ class METSDocument(object):
                 use = file_elem.getparent().get('USE')
                 path = file_elem.find('mets:FLocat', namespaces=utils.NAMESPACES).get(utils.lxmlns('xlink') + 'href')
                 amdids = file_elem.get('ADMID')
+                checksum = file_elem.get('CHECKSUM')
+                checksumtype = file_elem.get('CHECKSUMTYPE')
 
             # Recursively generate children
             children = self._parse_tree_structmap(tree, elem)
 
             # Create FSEntry
-            fs_entry = fsentry.FSEntry(path=path, label=label, use=use, type=entry_type, children=children, file_uuid=file_uuid, derived_from=derived_from)
+            fs_entry = fsentry.FSEntry(path=path, label=label, use=use, type=entry_type, children=children, file_uuid=file_uuid, derived_from=derived_from, checksum=checksum, checksumtype=checksumtype)
 
             # Add DMDSecs
             dmdids = elem.get('DMDID')

--- a/tests/test_fsentry.py
+++ b/tests/test_fsentry.py
@@ -68,19 +68,19 @@ class TestFSEntry(TestCase):
     def test_admids(self):
         """ It should return 0 or 1 amdSecs. """
         f = metsrw.FSEntry('file1.txt', file_uuid=str(uuid.uuid4()))
-        assert len(f.admids()) == 0
+        assert len(f.admids) == 0
         f.add_premis_object('<premis>object</premis>')
-        assert len(f.admids()) == 1
+        assert len(f.admids) == 1
         f.add_premis_event('<premis>event</premis>')
         # Can only have one amdSec
-        assert len(f.admids()) == 1
+        assert len(f.admids) == 1
 
     def test_dmdids(self):
         """ It should return a DMDID for each dmdSec. """
         f = metsrw.FSEntry('file1.txt', file_uuid=str(uuid.uuid4()))
-        assert len(f.dmdids()) == 0
+        assert len(f.dmdids) == 0
         f.add_dublin_core('<dc />')
-        assert len(f.dmdids()) == 1
+        assert len(f.dmdids) == 1
 
     def test_add_metadata_to_fsentry(self):
         f1 = metsrw.FSEntry('file1.txt', file_uuid=str(uuid.uuid4()))


### PR DESCRIPTION
* ADMID and DMDID are properties (backed by a function)
* Children and parents is bidirectional now
* Add str and repr for FSEntry
* Parse handles checksums