### PR TITLE
Reingest support

### DIFF
--- a/metsrw/fsentry.py
+++ b/metsrw/fsentry.py
@@ -147,12 +147,14 @@ class FSEntry(object):
         :param str loctype: Required if mode is 'mdref'. LOCTYPE of a mdRef
         :param str label: Optional. Label of a mdRef
         :param str otherloctype: Optional. OTHERLOCTYPE of a mdRef.
+        :param str othermdtype: Optional. OTHERMDTYPE of a mdWrap.
 
         """
         # HELP how handle multiple amdSecs?
         # When adding *MD which amdSec to add to?
         if mode.lower() == 'mdwrap':
-            mdsec = MDWrap(md, mdtype)
+            othermdtype = kwargs.get('othermdtype')
+            mdsec = MDWrap(md, mdtype, othermdtype)
         elif mode.lower() == 'mdref':
             loctype = kwargs.get('loctype')
             label = kwargs.get('label')

--- a/metsrw/fsentry.py
+++ b/metsrw/fsentry.py
@@ -63,12 +63,15 @@ class FSEntry(object):
 
     ALLOWED_CHECKSUMS = ('Adler-32', 'CRC32', 'HAVAL', 'MD5', 'MNP', 'SHA-1', 'SHA-256', 'SHA-384', 'SHA-512', 'TIGER WHIRLPOOL')
 
-    def __init__(self, path, label=None, use='original', type=u'Item', children=None, file_uuid=None, derived_from=None, checksum=None, checksumtype=None):
+    def __init__(self, path=None, label=None, use='original', type=u'Item', children=None, file_uuid=None, derived_from=None, checksum=None, checksumtype=None):
         # path can validly be any encoding; if this value needs
         # to be spliced later on, it's better to treat it as a
         # bytestring than as actually being encoded text.
-        self.path = str(path)
-        if label is None:
+        # TODO update this with six and bytes
+        if path:
+            path = str(path)
+        self.path = path
+        if label is None and path is not None:
             label = os.path.basename(path)
         self.label = label
         self.use = use
@@ -230,11 +233,12 @@ class FSEntry(object):
         if self.checksum and self.checksumtype:
             el.attrib['CHECKSUM'] = self.checksum
             el.attrib['CHECKSUMTYPE'] = self.checksumtype
-        flocat = etree.SubElement(el, utils.lxmlns('mets') + 'FLocat')
-        # Setting manually so order is correct
-        flocat.set(utils.lxmlns('xlink') + 'href', self.path)
-        flocat.set('LOCTYPE', 'OTHER')
-        flocat.set('OTHERLOCTYPE', 'SYSTEM')
+        if self.path:
+            flocat = etree.SubElement(el, utils.lxmlns('mets') + 'FLocat')
+            # Setting manually so order is correct
+            flocat.set(utils.lxmlns('xlink') + 'href', self.path)
+            flocat.set('LOCTYPE', 'OTHER')
+            flocat.set('OTHERLOCTYPE', 'SYSTEM')
 
         return el
 

--- a/metsrw/fsentry.py
+++ b/metsrw/fsentry.py
@@ -252,6 +252,8 @@ class FSEntry(object):
         :param bool recurse: If true, serialize and apppend all children.  Otherwise, only serialize this element but not any children.
         :return: structMap element for this FSEntry
         """
+        if not self.label:
+            return None
         el = etree.Element(utils.lxmlns('mets') + 'div', TYPE=self.type, LABEL=self.label)
         if self.file_id():
             etree.SubElement(el, utils.lxmlns('mets') + 'fptr', FILEID=self.file_id())
@@ -260,6 +262,8 @@ class FSEntry(object):
 
         if recurse and self._children:
             for child in self._children:
-                el.append(child.serialize_structmap(recurse=recurse))
+                child_el = child.serialize_structmap(recurse=recurse)
+                if child_el is not None:
+                    el.append(child_el)
 
         return el

--- a/metsrw/fsentry.py
+++ b/metsrw/fsentry.py
@@ -208,10 +208,41 @@ class FSEntry(object):
         return self.add_dmdsec(md, 'DC', mode)
 
     def add_child(self, child):
+        """
+        Add a child FSEntry to this FSEntry.
+
+        Only FSEntrys with a type of 'directory' can have children.
+
+        This does not detect cyclic parent/child relationships, but that will cause problems.
+
+        :param FSEntry child: FSEntry to add as a child
+        :return: The newly added child
+        :raises ValueError: If this FSEntry cannot have children.
+        :raises ValueError: If the child and the parent are the same
+        """
         if self.type.lower() != 'directory':
             raise ValueError("Only directory objects can have children")
-        self._children.append(child)
+        if child is self:
+            raise ValueError('Cannot be a child of itself!')
+        if child not in self._children:
+            self._children.append(child)
         child.parent = self
+        return child
+
+    def remove_child(self, child):
+        """
+        Remove a child from this FSEntry
+
+        If `child` is not actually a child of this entry, nothing happens.
+
+        :param child: Child to remove
+        """
+        try:
+            self._children.remove(child)
+        except ValueError:  # Child may not be in list
+            pass
+        else:
+            child.parent = None
 
     # SERIALIZE
 

--- a/metsrw/metadata.py
+++ b/metsrw/metadata.py
@@ -168,7 +168,7 @@ class SubSection(object):
         """
         subsection = root.tag.replace(utils.lxmlns('mets'), '', 1)
         if subsection not in cls.ALLOWED_SUBSECTIONS:
-            raise exceptions.exceptions.ParseError('SubSection can only parse elements with tag in %s with METS namespace' % cls.ALLOWED_SUBSECTIONS)
+            raise exceptions.ParseError('SubSection can only parse elements with tag in %s with METS namespace' % (cls.ALLOWED_SUBSECTIONS,))
         section_id = root.get('ID')
         created = root.get('CREATED')
         status = root.get('STATUS')
@@ -180,7 +180,7 @@ class SubSection(object):
             mdref = MDRef.parse(child)
             obj = cls(subsection, mdref, section_id)
         else:
-            raise exceptions.exceptions.ParseError('Child of %s must be mdWrap or mdRef' % subsection)
+            raise exceptions.ParseError('Child of %s must be mdWrap or mdRef' % subsection)
         obj.created = created
         obj.status = status
         return obj

--- a/metsrw/metadata.py
+++ b/metsrw/metadata.py
@@ -140,7 +140,7 @@ class SubSection(object):
                 return 'updated'
         if self.subsection in ('techMD', 'rightsMD',):
             # TODO how to handle ones where newer has been deleted?
-            if self.newer == None:
+            if self.newer is None:
                 return 'current'
             else:
                 return 'superseded'

--- a/metsrw/metadata.py
+++ b/metsrw/metadata.py
@@ -125,7 +125,7 @@ class SubSection(object):
 
         :returns: None or the STATUS string.
         """
-        if self.status:
+        if self.status is not None:
             return self.status
         if self.subsection == 'dmdSec':
             if self.older is None:
@@ -170,8 +170,8 @@ class SubSection(object):
         if subsection not in cls.ALLOWED_SUBSECTIONS:
             raise exceptions.ParseError('SubSection can only parse elements with tag in %s with METS namespace' % (cls.ALLOWED_SUBSECTIONS,))
         section_id = root.get('ID')
-        created = root.get('CREATED')
-        status = root.get('STATUS')
+        created = root.get('CREATED', '')
+        status = root.get('STATUS', '')
         child = root[0]
         if child.tag == utils.lxmlns('mets') + 'mdWrap':
             mdwrap = MDWrap.parse(child)
@@ -192,9 +192,9 @@ class SubSection(object):
         :param str now: Default value for CREATED if none set
         :return: dmdSec/techMD/rightsMD/sourceMD/digiprovMD Element with all children
         """
-        created = self.created or now
+        created = self.created if self.created is not None else now
         el = etree.Element(utils.lxmlns('mets') + self.subsection, ID=self.id_string())
-        if created:
+        if created:  # Don't add CREATED if none was parsed
             el.set('CREATED', created)
         status = self.get_status()
         if status:

--- a/metsrw/metadata.py
+++ b/metsrw/metadata.py
@@ -25,14 +25,18 @@ class AMDSec(object):
 
     :param str section_id: ID of the section. If not provided, will be generated from 'amdSec' and a random number.
     :param list subsections: List of :class:`SubSection` that are part of this amdSec
+    :param Element tree: An lxml.Element that is an externally generated amdSec.  This will overwrite any automatic serialization.  If passed, section_id must also be passed.
     """
     tag = 'amdSec'
 
-    def __init__(self, section_id=None, subsections=None):
+    def __init__(self, section_id=None, subsections=None, tree=None):
         if subsections is None:
             subsections = []
         self.subsections = subsections
         self._id = section_id
+        self._tree = tree
+        if tree is not None and not section_id:
+            raise ValueError('If tree is provided, section_id must also be provided')
 
     def id_string(self, force_generate=False):
         """
@@ -68,6 +72,8 @@ class AMDSec(object):
         :param str now: Default value for CREATED in children if none set
         :return: amdSec Element with all children
         """
+        if self._tree is not None:
+            return self._tree
         el = etree.Element(utils.lxmlns('mets') + self.tag, ID=self.id_string())
         self.subsections.sort()
         for child in self.subsections:

--- a/metsrw/metadata.py
+++ b/metsrw/metadata.py
@@ -289,15 +289,17 @@ class MDWrap(object):
     :param str document: A string copy of the document, and will be parsed into
         an ElementTree at the time of instantiation.
     :param str mdtype: The MDTYPE of XML document being enclosed. Examples
-        include "PREMIS:OBJECT" and "PREMIS:EVENT".
+        include "PREMIS:OBJECT", "PREMIS:EVENT,", "DC" and "OTHER".
+    :param str othermdtype: The OTHERMDTYPE of the XML document. Should be set if mdtype is "OTHER".
     """
-    def __init__(self, document, mdtype):
+    def __init__(self, document, mdtype, othermdtype=None):
         parser = etree.XMLParser(remove_blank_text=True)
         if isinstance(document, six.string_types):
             self.document = etree.fromstring(document, parser=parser)
         elif isinstance(document, etree._Element):
             self.document = document
         self.mdtype = mdtype
+        self.othermdtype = othermdtype
 
     @classmethod
     def parse(cls, root):
@@ -313,14 +315,17 @@ class MDWrap(object):
         mdtype = root.get('MDTYPE')
         if not mdtype:
             raise exceptions.ParseError('mdWrap must have a MDTYPE')
+        othermdtype = root.get('OTHERMDTYPE')
         document = root.xpath('mets:xmlData/*', namespaces=utils.NAMESPACES)
         if len(document) != 1:
             raise exceptions.ParseError('mdWrap and xmlData can only have one child')
         document = document[0]
-        return cls(document, mdtype)
+        return cls(document, mdtype, othermdtype)
 
     def serialize(self):
         el = etree.Element(utils.lxmlns('mets') + 'mdWrap', MDTYPE=self.mdtype)
+        if self.othermdtype:
+            el.attrib['OTHERMDTYPE'] = self.othermdtype
         xmldata = etree.SubElement(el, utils.lxmlns('mets') + 'xmlData')
         xmldata.append(self.document)
 

--- a/metsrw/metadata.py
+++ b/metsrw/metadata.py
@@ -138,7 +138,7 @@ class SubSection(object):
                 return 'original'
             else:
                 return 'updated'
-        if self.subsection == 'rightsMD':
+        if self.subsection in ('techMD', 'rightsMD',):
             # TODO how to handle ones where newer has been deleted?
             if self.newer == None:
                 return 'current'

--- a/metsrw/mets.py
+++ b/metsrw/mets.py
@@ -267,6 +267,11 @@ class METSDocument(object):
                     dmdsec_elem = tree.find('mets:dmdSec[@ID="' + dmdid + '"]', namespaces=utils.NAMESPACES)
                     dmdsec = metadata.SubSection.parse(dmdsec_elem)
                     fs_entry.dmdsecs.append(dmdsec)
+                # Create older/newer relationships
+                fs_entry.dmdsecs.sort(key=lambda x: x.created)
+                for prev_dmdsec, dmdsec in zip(fs_entry.dmdsecs, fs_entry.dmdsecs[1:]):
+                    if dmdsec.status == 'updated':
+                        prev_dmdsec.replace_with(dmdsec)
 
             # Add AMDSecs
             if amdids:

--- a/metsrw/mets.py
+++ b/metsrw/mets.py
@@ -150,6 +150,9 @@ class METSDocument(object):
                 dmdsecs.append(d)
             for a in f.amdsecs:
                 amdsecs.append(a)
+
+        dmdsecs.sort(key=lambda x: x.id_string())
+        amdsecs.sort(key=lambda x: x.id_string())
         return dmdsecs + amdsecs
 
     def _structmap(self):

--- a/metsrw/mets.py
+++ b/metsrw/mets.py
@@ -50,11 +50,8 @@ class METSDocument(object):
         :returns: Set containing all :class:`FSEntry` in this METS document,
             including descendants of ones explicitly added.
         """
-        # NOTE: Cannot use _collect_files_uuid and .values() because not all
-        # FSEntrys have UUIDs, and those without will be dropped.
-        if not self._all_files:
-            self._all_files = self._collect_all_files(self._root_elements)
-        return self._all_files
+        # FIXME cache this. Should not break when add_child is called on an element already in the document.
+        return self._collect_all_files(self._root_elements)
 
     def get_file(self, **kwargs):
         """

--- a/metsrw/mets.py
+++ b/metsrw/mets.py
@@ -87,6 +87,24 @@ class METSDocument(object):
         # Reset file lists so they get regenerated with the new files(s)
         self._all_files = None
 
+    def remove_entry(self, fs_entry):
+        """
+        Removes an FSEntry object from this METS document.
+
+        Any children of this FSEntry will also be removed. This will be removed as a child of it's parent, if any.
+
+        :param FSEntry fs_entry: FSEntry to remove from the METS
+        """
+        try:
+            self._root_elements.remove(fs_entry)
+        except ValueError:  # fs_entry may not be in the root elements
+            pass
+        if fs_entry.parent:
+            fs_entry.parent.remove_child(fs_entry)
+        # Reset file lists so they get regenerated without the removed file(s)
+        self._all_files = None
+
+
     # SERIALIZE
 
     def _document_root(self, fully_qualified=True):

--- a/metsrw/mets.py
+++ b/metsrw/mets.py
@@ -241,11 +241,9 @@ class METSDocument(object):
                 if file_elem is None:
                     raise exceptions.ParseError('%s exists in structMap but not fileSec' % file_id)
                 file_uuid = file_id.replace(utils.FILE_ID_PREFIX, '', 1)
-                group_uuid = file_elem.get('GROUPID')
-                if group_uuid:
-                    group_uuid.replace(utils.GROUP_ID_PREFIX, '', 1)
-                    if group_uuid != file_uuid:
-                        derived_from = group_uuid  # Use group_uuid as placeholder
+                group_uuid = file_elem.get('GROUPID', '').replace(utils.GROUP_ID_PREFIX, '', 1)
+                if group_uuid != file_uuid:
+                    derived_from = group_uuid  # Use group_uuid as placeholder
                 use = file_elem.getparent().get('USE')
                 path = file_elem.find('mets:FLocat', namespaces=utils.NAMESPACES).get(utils.lxmlns('xlink') + 'href')
                 amdids = file_elem.get('ADMID')

--- a/metsrw/mets.py
+++ b/metsrw/mets.py
@@ -151,7 +151,9 @@ class METSDocument(object):
                                   # TODO don't hardcode this
                                   LABEL='Archivematica default')
         for item in self._root_elements:
-            structmap.append(item.serialize_structmap(recurse=True))
+            child = item.serialize_structmap(recurse=True)
+            if child is not None:
+                structmap.append(child)
 
         return structmap
 

--- a/tests/test_fsentry.py
+++ b/tests/test_fsentry.py
@@ -111,6 +111,48 @@ class TestFSEntry(TestCase):
 
         assert len(f1.amdsecs[0].subsections) == 4
 
+    def test_add_child(self):
+        """
+        It should add a new entry to the children list.
+        It should add a parent link.
+        It should handle duplicates.
+        """
+        d = metsrw.FSEntry('dir', type='Directory')
+        f = metsrw.FSEntry('file1.txt', file_uuid=str(uuid.uuid4()))
+
+        d.add_child(f)
+        assert f in d.children
+        assert len(d.children) == 1
+        assert f.parent is d
+
+        d.add_child(f)
+        assert f in d.children
+        assert len(d.children) == 1
+        assert f.parent is d
+
+        with pytest.raises(ValueError):
+            f.add_child(d)
+
+    def test_remove_child(self):
+        """
+        It should remove the child from the parent's children list.
+        It should remove the parent from the child's parent link.
+        """
+        d = metsrw.FSEntry('dir', type='Directory')
+        f1 = metsrw.FSEntry('file1.txt', file_uuid=str(uuid.uuid4()))
+        f2 = metsrw.FSEntry('file2.txt', file_uuid=str(uuid.uuid4()))
+        d.add_child(f1)
+        d.add_child(f2)
+        assert f1 in d.children
+        assert f1.parent is d
+        assert len(d.children) == 2
+
+        d.remove_child(f1)
+
+        assert f1 not in d.children
+        assert f1.parent is None
+        assert len(d.children) == 1
+
     def test_serialize_filesec_basic(self):
         """
         It should produce a mets:file element.

--- a/tests/test_fsentry.py
+++ b/tests/test_fsentry.py
@@ -170,6 +170,20 @@ class TestFSEntry(TestCase):
         el = f.serialize_filesec()
         assert el is None
 
+    def test_serialize_filesec_no_path(self):
+        """
+        It should produce a mets:file element.
+        It should not have a child mets:FLocat.
+        """
+        file_uuid = str(uuid.uuid4())
+        f = metsrw.FSEntry(file_uuid=file_uuid, use='deletion')
+        el = f.serialize_filesec()
+        assert el.tag == '{http://www.loc.gov/METS/}file'
+        assert el.attrib['ID'] == 'file-' + file_uuid
+        assert el.attrib['GROUPID'] == 'Group-' + file_uuid
+        assert len(el.attrib) == 2
+        assert len(el) == 0
+
     def test_serialize_structmap_file(self):
         """
         It should produce a mets:div element.

--- a/tests/test_fsentry.py
+++ b/tests/test_fsentry.py
@@ -237,3 +237,20 @@ class TestFSEntry(TestCase):
         assert el[0][0].tag == '{http://www.loc.gov/METS/}fptr'
         assert el[0][0].attrib['FILEID'].startswith('file-')
 
+    def test_serialize_structmap_no_label(self):
+        """ It should return None. """
+        f = metsrw.FSEntry()
+        el = f.serialize_structmap(recurse=False)
+        assert el is None
+
+    def test_serialize_structmap_child_empty(self):
+        """ It should handle children with no structMap entry. """
+        d = metsrw.FSEntry('dir', type='Directory')
+        f = metsrw.FSEntry(use='deletion', file_uuid=str(uuid.uuid4()))
+        d.add_child(f)
+        el = d.serialize_structmap(recurse=True)
+        assert el.tag == '{http://www.loc.gov/METS/}div'
+        assert el.attrib['TYPE'] == 'Directory'
+        assert el.attrib['LABEL'] == 'dir'
+        assert len(el.attrib) == 2
+        assert len(el) == 0

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -13,6 +13,16 @@ class TestAMDSec(TestCase):
         amdsec = metsrw.AMDSec()
         assert amdsec.id_string()
 
+    def test_tree_no_id(self):
+        with pytest.raises(ValueError) as excinfo:
+            metsrw.AMDSec(tree=etree.Element('amdSec'))
+        assert 'section_id' in str(excinfo.value)
+
+    def test_tree_overwrites_serialize(self):
+        elem = etree.Element('temp')
+        amdsec = metsrw.AMDSec(tree=elem, section_id='id1')
+        assert amdsec.serialize() == elem
+
 
 class TestSubSection(TestCase):
     """ Test SubSection class. """

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -51,8 +51,8 @@ class TestSubSection(TestCase):
         techmd_old = metsrw.SubSection('techMD', self.STUB_MDWRAP)
         techmd_new = metsrw.SubSection('techMD', self.STUB_MDWRAP)
         techmd_old.replace_with(techmd_new)
-        assert techmd_old.get_status() is None
-        assert techmd_new.get_status() is None
+        assert techmd_old.get_status() is 'superseded'
+        assert techmd_new.get_status() is 'current'
 
     def test_replacement_sourcemd(self):
         """ It should have no special behaviour replacing sourceMDs. """
@@ -114,7 +114,8 @@ class TestSubSection(TestCase):
         assert root.tag == '{http://www.loc.gov/METS/}techMD'
         assert root.attrib['ID'] == 'techMD_1'
         assert root.attrib['CREATED'] == '2014-07-23T21:48:33'
-        assert len(root.attrib) == 2
+        assert root.attrib['STATUS'] == 'current'
+        assert len(root.attrib) == 3
         assert len(root) == 1
         assert root[0].tag == 'dummy_data'
 
@@ -127,7 +128,8 @@ class TestSubSection(TestCase):
         root = subsection.serialize()
         assert root.tag == '{http://www.loc.gov/METS/}techMD'
         assert root.attrib['ID'] == 'techMD_1'
-        assert len(root.attrib) == 1
+        assert root.attrib['STATUS'] == 'current'
+        assert len(root.attrib) == 2
         assert len(root) == 1
         assert root[0].tag == 'dummy_data'
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -110,9 +110,13 @@ class TestSubSection(TestCase):
         subsection = metsrw.SubSection('techMD', content)
         subsection._id = 'techMD_1'
 
-        target = b'<ns0:techMD xmlns:ns0="http://www.loc.gov/METS/" ID="techMD_1" CREATED="2014-07-23T21:48:33"><dummy_data/></ns0:techMD>'
-
-        assert etree.tostring(subsection.serialize("2014-07-23T21:48:33")) == target
+        root = subsection.serialize("2014-07-23T21:48:33")
+        assert root.tag == '{http://www.loc.gov/METS/}techMD'
+        assert root.attrib['ID'] == 'techMD_1'
+        assert root.attrib['CREATED'] == '2014-07-23T21:48:33'
+        assert len(root.attrib) == 2
+        assert len(root) == 1
+        assert root[0].tag == 'dummy_data'
 
     def test_subsection_serialize_no_date(self):
         content = metsrw.MDWrap('<foo/>', None)
@@ -120,9 +124,12 @@ class TestSubSection(TestCase):
         subsection = metsrw.SubSection('techMD', content)
         subsection._id = 'techMD_1'
 
-        target = b'<ns0:techMD xmlns:ns0="http://www.loc.gov/METS/" ID="techMD_1"><dummy_data/></ns0:techMD>'
-
-        assert etree.tostring(subsection.serialize()) == target
+        root = subsection.serialize()
+        assert root.tag == '{http://www.loc.gov/METS/}techMD'
+        assert root.attrib['ID'] == 'techMD_1'
+        assert len(root.attrib) == 1
+        assert len(root) == 1
+        assert root[0].tag == 'dummy_data'
 
     def test_subsection_ordering(self):
         l = []

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -159,6 +159,29 @@ class TestSubSection(TestCase):
             metsrw.SubSection.parse(elem)
             assert 'must be mdWrap or mdRef' in e.value
 
+    def test_roundtrip(self):
+        """ It should be able to parse and write out a subsection unchanged. """
+        elem = etree.Element('{http://www.loc.gov/METS/}techMD', ID='techMD_42', CREATED='2016-01-02T03:04:05', STATUS='original')
+        mdr = etree.SubElement(elem, '{http://www.loc.gov/METS/}mdRef', MDTYPE='dummy', LOCTYPE='URL')
+        mdr.set('{http://www.w3.org/1999/xlink}href', 'url')
+        obj = metsrw.SubSection.parse(elem)
+        new = obj.serialize(now='2001-02-03T09:10')
+        assert new.tag == '{http://www.loc.gov/METS/}techMD'
+        assert new.attrib['ID'] == 'techMD_42'
+        assert new.attrib['CREATED'] == '2016-01-02T03:04:05'
+        assert new.attrib['STATUS'] == 'original'
+        assert len(new.attrib) == 3
+
+    def test_roundtrip_bare(self):
+        """ It should be able to parse and write out a subsection unchanged. """
+        elem = etree.Element('{http://www.loc.gov/METS/}techMD', ID='techMD_42')
+        mdr = etree.SubElement(elem, '{http://www.loc.gov/METS/}mdRef', MDTYPE='dummy', LOCTYPE='URL')
+        mdr.set('{http://www.w3.org/1999/xlink}href', 'url')
+        obj = metsrw.SubSection.parse(elem)
+        new = obj.serialize(now='2001-02-03T09:10')
+        assert new.tag == '{http://www.loc.gov/METS/}techMD'
+        assert new.attrib['ID'] == 'techMD_42'
+        assert len(new.attrib) == 1
 
 class TestMDRef(TestCase):
     """ Test MDRef class. """

--- a/tests/test_mets.py
+++ b/tests/test_mets.py
@@ -242,6 +242,40 @@ class TestWholeMETS(TestCase):
         assert mw.get_file(file_uuid=f4_uuid) == f4
         assert mw.get_file(path='file4.txt') == f4
 
+    def test_remove_file(self):
+        """ It should """
+        # Setup
+        f3_uuid = str(uuid.uuid4())
+        f3 = metsrw.FSEntry('dir1/dir2/level3.txt', file_uuid=f3_uuid)
+        d2 = metsrw.FSEntry('dir1/dir2', type='Directory', children=[f3])
+        f2_uuid = str(uuid.uuid4())
+        f2 = metsrw.FSEntry('dir1/level2.txt', file_uuid=f2_uuid)
+        d1 = metsrw.FSEntry('dir1', type='Directory', children=[d2, f2])
+        f1_uuid = str(uuid.uuid4())
+        f1 = metsrw.FSEntry('level1.txt', file_uuid=f1_uuid)
+        d = metsrw.FSEntry('root', type='Directory', children=[d1, f1])
+        mw = metsrw.METSDocument()
+        mw.append_file(d)
+        assert len(mw.all_files()) == 6
+        # Test remove file
+        mw.remove_entry(f3)
+        assert len(mw.all_files()) == 5
+        assert mw.get_file(file_uuid=f3_uuid) is None
+        assert f3 not in d2.children
+        assert f3 not in mw.all_files()
+        # Test remove dir
+        mw.remove_entry(d1)
+        assert len(mw.all_files()) == 2
+        assert mw.get_file(path='dir1') is None
+        assert d1 not in d.children
+        assert d1 not in mw.all_files()
+        assert f2 not in mw.all_files()
+        assert d2 not in mw.all_files()
+        assert f1 in d.children
+        # Test remove root element
+        mw.remove_entry(d)
+        assert len(mw.all_files()) == 0
+
     def test_collect_mdsec_elements(self):
         f1 = metsrw.FSEntry('file1.txt', file_uuid=str(uuid.uuid4()))
         f1.amdsecs.append(metsrw.AMDSec())

--- a/tests/test_mets.py
+++ b/tests/test_mets.py
@@ -235,28 +235,44 @@ class TestWholeMETS(TestCase):
         # TODO test file & FLocat
 
     def test_structmap(self):
+        """
+        It should create a structMap tag.
+        It should have a div tag for the directory.
+        It should have div tags for the children beneath the directory.
+        It should not have div tags for deleted files (without label).
+        """
         children = [
             metsrw.FSEntry('objects/file1.txt', file_uuid=str(uuid.uuid4())),
             metsrw.FSEntry('objects/file2.txt', file_uuid=str(uuid.uuid4())),
         ]
         parent = metsrw.FSEntry('objects', type='Directory', children=children)
+        deleted_f = metsrw.FSEntry(use='deletion', file_uuid=str(uuid.uuid4()))
+
         writer = metsrw.METSDocument()
         writer.append_file(parent)
+        writer.append_file(deleted_f)
         sm = writer._structmap()
 
-        parent = sm.find('{http://www.loc.gov/METS/}div')
-        children = parent.getchildren()
-
         assert sm.tag == '{http://www.loc.gov/METS/}structMap'
-        assert len(children) == 2
-        assert parent.get('LABEL') == 'objects'
-        assert parent.get('TYPE') == 'Directory'
-        assert children[0].get('LABEL') == 'file1.txt'
-        assert children[0].get('TYPE') == 'Item'
-        assert children[0].find('{http://www.loc.gov/METS/}fptr') is not None
-        assert children[1].get('LABEL') == 'file2.txt'
-        assert children[1].get('TYPE') == 'Item'
-        assert children[1].find('{http://www.loc.gov/METS/}fptr') is not None
+        assert sm.attrib['TYPE'] == 'physical'
+        assert sm.attrib['ID'] == 'structMap_1'
+        assert sm.attrib['LABEL'] == 'Archivematica default'
+        assert len(sm.attrib) == 3
+        assert len(sm) == 1
+        parent = sm[0]
+        assert parent.tag == '{http://www.loc.gov/METS/}div'
+        assert parent.attrib['LABEL'] == 'objects'
+        assert parent.attrib['TYPE'] == 'Directory'
+        assert len(parent.attrib) == 2
+        assert len(parent) == 2
+        assert parent[0].attrib['LABEL'] == 'file1.txt'
+        assert parent[0].attrib['TYPE'] == 'Item'
+        assert len(parent[0].attrib) == 2
+        assert parent[0].find('{http://www.loc.gov/METS/}fptr') is not None
+        assert parent[1].attrib['LABEL'] == 'file2.txt'
+        assert parent[1].attrib['TYPE'] == 'Item'
+        assert len(parent[1].attrib) == 2
+        assert parent[1].find('{http://www.loc.gov/METS/}fptr') is not None
 
     def test_full_mets(self):
         mw = metsrw.METSDocument()

--- a/tests/test_mets.py
+++ b/tests/test_mets.py
@@ -135,6 +135,28 @@ class TestWholeMETS(TestCase):
         assert len(files) == 7
         assert f4 in files
 
+    def test_add_file_to_child(self):
+        # Test collects several children deep
+        f2 = metsrw.FSEntry('level2.txt', file_uuid=str(uuid.uuid4()))
+        d1 = metsrw.FSEntry('dir1', type='Directory', children=[f2])
+        f1 = metsrw.FSEntry('level1.txt', file_uuid=str(uuid.uuid4()))
+        d = metsrw.FSEntry('root', type='Directory', children=[d1, f1])
+        mw = metsrw.METSDocument()
+        mw.append_file(d)
+        files = mw.all_files()
+        assert files
+        assert len(files) == 4
+        assert d in files
+        assert f1 in files
+        assert d1 in files
+        assert f2 in files
+
+        f3 = metsrw.FSEntry('level3.txt', file_uuid=str(uuid.uuid4()))
+        d1.add_child(f3)
+        files = mw.all_files()
+        assert len(files) == 5
+        assert f3 in files
+
     def test_get_file(self):
         # Setup
         f3_uuid = str(uuid.uuid4())


### PR DESCRIPTION
Changes related to METS changes on reingest. Related to artefactual/archivematica#391  This may be broken into multiple PRs later.

* Sort amdSecs and dmdSecs by ID
* get_file takes **kwargs to search on multiple attributes
* Improve parsing - don't set CREATED or STATUS, get replacement relationships for dmdSecs, 
* Add MDWrap OTHERMDTYPE to metadata add contstructors
* Allow pre-created amdSecs (for compatibility with old ways of creating amdSecs, notably createMETS2 in Archivematica)
* FSEntrys no longer require path or label, which means the FLocat and structMap/div are optionally generated.
* techMD can be superseded
* Fix GROUPID parsing
* Update tests