### PR TITLE
MDWrap constructable with etree._Element or list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,12 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the relevant file
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
     name='metsrw',
-    version='0.1.1',
+    version='0.1.2',
 
     description='Library for dealing with METS files.',
     long_description=long_description,


### PR DESCRIPTION
Prior to this, metsrw was unable to handle mets:mdWrap/mets:smlData
elements containing multiple children: it expected a single child or
else it failed. However, this is problematic because namespace-less
metadata (i.e., from a metadata.csv file) can result in many such
children. This breaks re-ingest of AIPs with such descriptive metadata
(refs issue #11100).