### PR TITLE
Hwesta: Packaging tweaks

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include metsrw/resources/*
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,6 @@ setup(
 
     install_requires=['future', 'lxml', 'six'],
 
-    include_package_data=True
+    include_package_data=True,
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
 )


### PR DESCRIPTION
Replaces https://github.com/artefactual-labs/mets-reader-writer/pull/35 with a rebased branch.

Include the LICENSE file in the package uploaded to PyPI so users of this package are following the terms.

Update setup.py to only allow installing this on supported versions of Python.