### PR TITLE
premis: stop encoding unicode

### DIFF
--- a/metsrw/plugins/premisrw/premis.py
+++ b/metsrw/plugins/premisrw/premis.py
@@ -488,8 +488,10 @@ def _data_to_lxml_el(data, ns, nsmap, element_maker=None, snake=True):
         elif isinstance(element, (tuple, list)):
             args.append(_data_to_lxml_el(
                 element, ns, nsmap, element_maker=element_maker, snake=snake))
+        elif isinstance(element, six.text_type):
+            args.append(element)
         else:
-            args.append(str(element))
+            args.append(six.binary_type(element))
     ret = func(*args)
     for attr, val in attributes.items():
         try:

--- a/tests/plugins/premisrw/test_premis.py
+++ b/tests/plugins/premisrw/test_premis.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from unittest import TestCase
 
 import pytest
@@ -18,6 +19,21 @@ class TestPREMIS(TestCase):
         lxml_el = premisrw.data_to_premis(c.EX_COMPR_EVT)
         data = premisrw.premis_to_data(lxml_el)
         assert data == c.EX_COMPR_EVT
+
+    def test_roundtrip_unicode(self):
+        """Test the roundtripping with unicode values."""
+        lxml_el = premisrw.data_to_premis((
+            'agent',
+            premisrw.PREMIS_META,
+            (
+                'agent_identifier',
+                ('agent_identifier_type', u'𝕡𝕣𝕖𝕤𝕖𝕣𝕧𝕒𝕥𝕚𝕠𝕟 𝕤𝕪𝕤𝕥𝕖𝕞'),
+                ('agent_identifier_value', u'𝓊𝓃𝒾𝒸𝑜𝒹𝑒'),
+            )
+        ))
+        data = premisrw.premis_to_data(lxml_el)
+        assert data[2][1][1] == u'𝕡𝕣𝕖𝕤𝕖𝕣𝕧𝕒𝕥𝕚𝕠𝕟 𝕤𝕪𝕤𝕥𝕖𝕞'
+        assert data[2][2][1] == u'𝓊𝓃𝒾𝒸𝑜𝒹𝑒'
 
     def test_premis_event_cls_data(self):
         """Tests that you can pass a Python tuple as the ``data`` argument to

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,4 @@ commands = flake8 .
 
 [flake8]
 exclude = .tox, .git, __pycache__, .cache, build, dist, *.pyc, *.egg-info, .eggs, docs
-ignore = E501
+ignore = E501, W504


### PR DESCRIPTION
Text values (`unicode` in Py2 aka `str` in Py3) were being encoded using the
`ascii` encoder. This was raising `UnicodeEncodeError` with certain values.
Letting lxml handle text values seems to be a better approach.

This connects to https://github.com/archivematica/Issues/issues/260.