### PR TITLE
premisrw: always return unicode in text getter

### DIFF
--- a/metsrw/__init__.py
+++ b/metsrw/__init__.py
@@ -43,7 +43,7 @@ from . import plugins
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 __all__ = [
     'AMDSec',

--- a/metsrw/plugins/premisrw/premis.py
+++ b/metsrw/plugins/premisrw/premis.py
@@ -699,10 +699,13 @@ def data_find_text(data, path):
              if not isinstance(child, (tuple, list, dict))]
     if not texts:
         return None
-    if six.PY2:
-        return ' '.join(
-            [x.encode('utf-8', errors='ignore') for x in texts])
-    return ' '.join([str(x) for x in texts])
+    return ' '.join([
+        # How should we deal with decoding errors when `x` is binary?
+        # For now, we're using the ``strict`` mode. Other options here:
+        # https://docs.python.org/3/library/functions.html#open.
+        six.ensure_text(x, encoding='utf-8', errors='strict')
+        for x in texts
+    ])
 
 
 def data_find_text_or_all(data, path, dyn_cls=False):


### PR DESCRIPTION
See https://github.com/artefactual-labs/mets-reader-writer/commit/a08cec3dd56507a824e6251a319ad68d7ac97fe0 for more details.

Connects to https://github.com/archivematica/Issues/issues/295.

---

Question: should we release as metsrw 0.4.0 instead? Is it a bug or a fix considering that this is Py2-specific and perhaps more of an oversight but still an API change? :smile: 