### PR TITLE
premisrw: Allow embedded XML for objectCharacteristicsExtension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: xenial
 language: python
 
 install:
@@ -14,6 +15,8 @@ matrix:
       env: TOXENV=py34
     - python: 3.6
       env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
 
 script:
   - tox -e $TOXENV

--- a/metsrw/mets.py
+++ b/metsrw/mets.py
@@ -470,56 +470,42 @@ class METSDocument(object):
     def _validate(self):
         raise NotImplementedError()
 
-    def _fromfile(self, path):
+    @classmethod
+    def fromfile(cls, path):
         """
-        Accept a filepath pointing to a valid METS document and parses it.
+        Creates a METS by parsing a file.
 
         :param str path: Path to a METS document.
         """
         parser = etree.XMLParser(remove_blank_text=True)
-        self.tree = etree.parse(path, parser=parser)
-        self._parse_tree(self.tree)
+
+        return cls.fromtree(etree.parse(path, parser=parser))
 
     @classmethod
-    def fromfile(cls, path):
-        """ Creates a METS by parsing a file. """
-        i = cls()
-        i._fromfile(path)
-        return i
-
-    def _fromstring(self, string):
+    def fromstring(cls, string):
         """
-        Accept a string containing valid METS xml and parses it.
+        Create a METS by parsing a string.
 
         :param str string: String containing a METS document.
         """
         parser = etree.XMLParser(remove_blank_text=True)
         root = etree.fromstring(string, parser)
-        self.tree = root.getroottree()
-        self._parse_tree(self.tree)
+        tree = root.getroottree()
 
-    @classmethod
-    def fromstring(cls, string):
-        """ Create a METS by parsing a string. """
-        i = cls()
-        i._fromstring(string)
-        return i
-
-    def _fromtree(self, tree):
-        """
-        Accept an ElementTree or Element and parses it.
-
-        :param ElementTree tree: ElementTree to build a METS document from.
-        """
-        self.tree = tree
-        self._parse_tree(self.tree)
+        return cls.fromtree(tree)
 
     @classmethod
     def fromtree(cls, tree):
-        """ Create a METS from an ElementTree or Element. """
-        i = cls()
-        i._fromtree(tree)
-        return i
+        """
+        Create a METS from an ElementTree or Element.
+
+        :param ElementTree tree: ElementTree to build a METS document from.
+        """
+        mets = cls()
+        mets.tree = tree
+        mets._parse_tree(tree)
+
+        return mets
 
 
 if __name__ == '__main__':

--- a/metsrw/plugins/premisrw/premis.py
+++ b/metsrw/plugins/premisrw/premis.py
@@ -298,7 +298,8 @@ class PREMISObject(PREMISElement):
                     'inhibitors',
                     ('inhibitor_type',),
                     ('inhibitor_target',),
-                )
+                ),
+                ('object_characteristics_extension',)
             ),
             (
                 'relationship',
@@ -489,6 +490,8 @@ def _data_to_lxml_el(data, ns, nsmap, element_maker=None, snake=True):
             args.append(_data_to_lxml_el(
                 element, ns, nsmap, element_maker=element_maker, snake=snake))
         elif isinstance(element, six.text_type):
+            args.append(element)
+        elif isinstance(element, etree._Element):
             args.append(element)
         else:
             args.append(six.binary_type(element))

--- a/tests/plugins/premisrw/test_premis.py
+++ b/tests/plugins/premisrw/test_premis.py
@@ -2,6 +2,7 @@
 from unittest import TestCase
 
 import pytest
+from lxml import etree
 
 import metsrw
 import metsrw.plugins.premisrw as premisrw
@@ -364,3 +365,29 @@ class TestPREMIS(TestCase):
                     assert pres_deriv_uuid
                     pres_deriv_fsentry = mets.get_file(file_uuid=pres_deriv_uuid)
                     assert pres_deriv_fsentry.path == orig_to_pres_deriv[fsentry.path]
+
+    def test_object_characteristics_extension(self):
+        """
+        Test the object characteristics extension container element with embedded XML.
+        """
+        embedded_xml = etree.Element('arbitrary-xml')
+        child_element = etree.Element('a-child-element')
+        child_element.text = "Hello world"
+        embedded_xml.append(child_element)
+
+        premis_element = premisrw.data_to_premis((
+            'object',
+            premisrw.PREMIS_META,
+            (
+                'object_identifier',
+                ('object_identifier_type', 'UUID'),
+                ('object_identifier_value', '8bce611a-fabc-4161-8108-ba041fb8e7b4'),
+            ),
+            (
+                'object_characteristics',
+                ('object_characteristics_extension', embedded_xml)
+            )
+        ))
+
+        xpath_lookup = './/premis:objectCharacteristicsExtension/arbitrary-xml'
+        assert premis_element.xpath(xpath_lookup, namespaces=premis_element.nsmap)[0] == embedded_xml

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -52,8 +52,8 @@ class TestSubSection(TestCase):
         techmd_old = metsrw.SubSection('techMD', self.STUB_MDWRAP)
         techmd_new = metsrw.SubSection('techMD', self.STUB_MDWRAP)
         techmd_old.replace_with(techmd_new)
-        assert techmd_old.get_status() is 'superseded'
-        assert techmd_new.get_status() is 'current'
+        assert techmd_old.get_status() == 'superseded'
+        assert techmd_new.get_status() == 'current'
 
     def test_replacement_sourcemd(self):
         """ It should have no special behaviour replacing sourceMDs. """

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,36}, flake8
+envlist = py{27,34,36,37}, flake8
 skip_missing_interpreters = True
 skipsdist = True
 


### PR DESCRIPTION
Required for including FITS/Siegfried output in METS files.

Also a little cleanup and added py37 tests. I can break those out if preferred.

Connects to https://github.com/archivematica/Issues/issues/442.