### PR TITLE
Read and write OBJID (metsType attr)

### DIFF
--- a/metsrw/mets.py
+++ b/metsrw/mets.py
@@ -33,6 +33,7 @@ class METSDocument(object):
         # Only root-level elements are stored, since the rest
         # can be inferred via their #children attribute
         self.createdate = None
+        self.objid = None
         self._root_elements = []
         self._all_files = None
         self._iter = None
@@ -161,8 +162,7 @@ class METSDocument(object):
 
     # SERIALIZE
 
-    @staticmethod
-    def _document_root(fully_qualified=True):
+    def _document_root(self, fully_qualified=True):
         """
         Return the mets Element for the document root.
         """
@@ -178,6 +178,8 @@ class METSDocument(object):
             '{}schemaLocation'.format(utils.lxmlns('xsi')):
             utils.SCHEMA_LOCATIONS
         }
+        if self.objid:
+            attrib['OBJID'] = self.objid
         return etree.Element(utils.lxmlns('mets') + 'mets', nsmap=nsmap, attrib=attrib)
 
     def _mets_header(self, now):
@@ -469,6 +471,12 @@ class METSDocument(object):
             raise exceptions.ParseError(
                 'CREATEDATE more recent than now (%s)' % now)
         self.createdate = createdate
+
+        # Read root attributes
+        root = tree
+        if isinstance(tree, etree._ElementTree):
+            root = tree.getroot()
+        self.objid = root.get('OBJID', None)
 
         # Parse structMap
         structMap = tree.find('mets:structMap[@TYPE="physical"]',

--- a/tests/test_mets.py
+++ b/tests/test_mets.py
@@ -132,6 +132,11 @@ class TestMETSDocument(TestCase):
         }
         assert root.nsmap == nsmap
 
+    def test_mets_root_attributes(self):
+        mw = metsrw.METSDocument().fromfile('fixtures/mets_without_groupid_in_file.xml')
+        assert mw.objid == "44db0a40-4c76-45b9-83f1-a8adba434b43"
+        assert mw._document_root().attrib["OBJID"] == "44db0a40-4c76-45b9-83f1-a8adba434b43"
+
     def test_mets_header(self):
         mw = metsrw.METSDocument()
         date = '2014-07-16T22:52:02.480108'


### PR DESCRIPTION
`metsType` supports attributes like `LABEL` or `TYPE`. Consider this
an early implementation targeting a single attribute (`OBJID`) whereas a better
solution with support for arbitrary fields will require further work.

About `metsType` from the spec:

> It also has five possible attributes: 1. ID (an XML ID); 2. OBJID: a primary identifier assigned to the original source document; 3. LABEL: a title/text string identifying the document for users; 4. TYPE: a type for the object, e.g., book, journal, stereograph, etc.; and 5. PROFILE: the registered profile to which this METS document conforms. METS registry information is available from the Library of Congress at http://www.loc.gov/mets.