### PR TITLE
Fix empty PREMIS:OBJECT errors

### DIFF
--- a/metsrw/__init__.py
+++ b/metsrw/__init__.py
@@ -43,7 +43,7 @@ from . import plugins
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 __all__ = [
     "Agent",

--- a/metsrw/fsentry.py
+++ b/metsrw/fsentry.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from itertools import chain
 import logging
 import os
-from random import randint
 
 from lxml import etree
 import six
@@ -191,9 +190,6 @@ class FSEntry(DependencyPossessor):
         )
 
     # PROPERTIES
-
-    def _create_id(self, prefix):
-        return prefix + "_" + str(randint(1, 999999))
 
     def file_id(self):
         """ Returns the fptr @FILEID if this is not a Directory. """

--- a/metsrw/metadata.py
+++ b/metsrw/metadata.py
@@ -4,6 +4,7 @@ Classes for metadata sections of the METS. Include amdSec, dmdSec, techMD, right
 """
 from __future__ import absolute_import
 
+import copy
 import logging
 from lxml import etree
 from random import randint
@@ -469,6 +470,10 @@ class MDWrap(object):
             )
         elif len(document) == 1:
             document = document[0]
+
+        # Create a copy, so that the element is not moved by duplicate references.
+        document = copy.deepcopy(document)
+
         return cls(document, mdtype, othermdtype)
 
     def serialize(self):

--- a/metsrw/metadata.py
+++ b/metsrw/metadata.py
@@ -4,17 +4,29 @@ Classes for metadata sections of the METS. Include amdSec, dmdSec, techMD, right
 """
 from __future__ import absolute_import
 
+import collections
 import copy
 import logging
 from lxml import etree
-from random import randint
 
 import six
 
 from . import exceptions
 from . import utils
 
+
 LOGGER = logging.getLogger(__name__)
+_id_counter = collections.Counter()
+
+
+def _generate_id(prefix):
+    """
+    Generate a counter based id for the prefix given.
+    """
+    count = _id_counter[prefix]
+    _id_counter.update([prefix])
+
+    return "{}_{}".format(prefix, count)
 
 
 class AMDSec(object):
@@ -49,7 +61,7 @@ class AMDSec(object):
         """
         # e.g., amdSec_1
         if force_generate or not self._id:
-            self._id = self.tag + "_" + str(randint(1, 999999))
+            self._id = _generate_id(self.tag)
         return self._id
 
     @classmethod
@@ -230,7 +242,7 @@ class SubSection(object):
         :param bool force_generate: If True, will generate a new ID from the subsection tag and a random number.
         """
         if force_generate or not self._id:
-            self._id = self.subsection + "_" + str(randint(1, 999999))
+            self._id = _generate_id(self.subsection)
         return self._id
 
     def get_status(self):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -420,11 +420,11 @@ class TestMDWrap(TestCase):
             "{http://www.loc.gov/METS/}mdWrap", MDTYPE="OTHER", OTHERMDTYPE="SYSTEM"
         )
         xmldata = etree.SubElement(good, "{http://www.loc.gov/METS/}xmlData")
-        document = etree.SubElement(xmldata, "foo")
+        etree.SubElement(xmldata, "foo")
         mdwrap = metsrw.MDWrap.parse(good)
         assert mdwrap.mdtype == "OTHER"
         assert mdwrap.othermdtype == "SYSTEM"
-        assert mdwrap.document == document
+        assert etree.tostring(mdwrap.document) == etree.tostring(etree.Element("foo"))
 
     def test_serialize_defaults(self):
         mdwrap = metsrw.MDWrap("<foo/>", "PREMIS:DUMMY")

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -75,10 +75,19 @@ class TestAgent(TestCase):
 class TestAMDSec(TestCase):
     """ Test AMDSec class. """
 
+    def setUp(self):
+        # Reset the id generation counter per test
+        metsrw.metadata._id_counter.clear()
+
     def test_identifier(self):
-        # should be in the format 'amdSec_1'
-        amdsec = metsrw.AMDSec()
-        assert amdsec.id_string()
+        amdsec_ids = [metsrw.AMDSec().id_string() for _ in range(10)]
+        # Generate a SubSection in between to make sure our count
+        # doesn't jump
+        metsrw.SubSection("techMD", []).id_string()
+        amdsec_ids.append(metsrw.AMDSec().id_string())
+
+        for index, amdsec_id in enumerate(amdsec_ids):
+            assert amdsec_id == "amdSec_{}".format(index)
 
     def test_tree_no_id(self):
         with pytest.raises(ValueError) as excinfo:
@@ -95,6 +104,20 @@ class TestSubSection(TestCase):
     """ Test SubSection class. """
 
     STUB_MDWRAP = metsrw.MDWrap("<foo/>", "PREMIS:DUMMY")
+
+    def setUp(self):
+        # Reset the id generation counter per test
+        metsrw.metadata._id_counter.clear()
+
+    def test_identifier(self):
+        tech_md_ids = [metsrw.SubSection("techMD", []).id_string() for _ in range(10)]
+        dmdsec_ids = [metsrw.SubSection("dmdSec", []).id_string() for _ in range(10)]
+
+        for index, tech_md_id in enumerate(tech_md_ids):
+            assert tech_md_id == "techMD_{}".format(index)
+
+        for index, dmdsec_id in enumerate(dmdsec_ids):
+            assert dmdsec_id == "dmdSec_{}".format(index)
 
     def test_allowed_tags(self):
         """ It should only allow certain subsection tags. """

--- a/tests/test_mets.py
+++ b/tests/test_mets.py
@@ -276,7 +276,6 @@ class TestMETSDocument(TestCase):
         assert fptr.file_uuid == "7327b00f-d83a-4ae8-bb89-84fce994e827"
         assert fptr.use == "Archival Information Package"
 
-    @pytest.mark.xfail(raises=metsrw.ParseError)
     @mock.patch("metsrw.fsentry.randint", return_value=1)
     @mock.patch("metsrw.metadata.randint", return_value=1)
     def test_duplicate_ids(self, mock_md_randint, mock_fs_randint):
@@ -289,7 +288,7 @@ class TestMETSDocument(TestCase):
         document.append_file(fsentry2)
 
         reloaded_document = metsrw.METSDocument.fromtree(document.serialize())
-        # Third time's the charm
+        # Third time's the charm - previously this failed
         metsrw.METSDocument.fromtree(reloaded_document.serialize())
 
 

--- a/tests/test_mets.py
+++ b/tests/test_mets.py
@@ -276,9 +276,8 @@ class TestMETSDocument(TestCase):
         assert fptr.file_uuid == "7327b00f-d83a-4ae8-bb89-84fce994e827"
         assert fptr.use == "Archival Information Package"
 
-    @mock.patch("metsrw.fsentry.randint", return_value=1)
-    @mock.patch("metsrw.metadata.randint", return_value=1)
-    def test_duplicate_ids(self, mock_md_randint, mock_fs_randint):
+    @mock.patch("metsrw.metadata._generate_id", return_value="id_1")
+    def test_duplicate_ids(self, mock_generate_id):
         document = metsrw.METSDocument()
         fsentry1 = metsrw.FSEntry("file[1].txt", file_uuid=str(uuid.uuid4()))
         fsentry1.add_premis_object("<premis>object</premis>")

--- a/tests/test_mets.py
+++ b/tests/test_mets.py
@@ -276,6 +276,22 @@ class TestMETSDocument(TestCase):
         assert fptr.file_uuid == "7327b00f-d83a-4ae8-bb89-84fce994e827"
         assert fptr.use == "Archival Information Package"
 
+    @pytest.mark.xfail(raises=metsrw.ParseError)
+    @mock.patch("metsrw.fsentry.randint", return_value=1)
+    @mock.patch("metsrw.metadata.randint", return_value=1)
+    def test_duplicate_ids(self, mock_md_randint, mock_fs_randint):
+        document = metsrw.METSDocument()
+        fsentry1 = metsrw.FSEntry("file[1].txt", file_uuid=str(uuid.uuid4()))
+        fsentry1.add_premis_object("<premis>object</premis>")
+        fsentry2 = metsrw.FSEntry("file[2].txt", file_uuid=str(uuid.uuid4()))
+        fsentry2.add_premis_object("<premis>object</premis>")
+        document.append_file(fsentry1)
+        document.append_file(fsentry2)
+
+        reloaded_document = metsrw.METSDocument.fromtree(document.serialize())
+        # Third time's the charm
+        metsrw.METSDocument.fromtree(reloaded_document.serialize())
+
 
 class TestWholeMETS(TestCase):
     """ Test integration between classes. """


### PR DESCRIPTION
I found this issue hard to debug because there are a couple things interacting:
1. duplicate ids are generated due to `randint` usage
2. duplicate ids results in multiple in memory references to the same xml element on the next metsrw parse of the document
3. lxml recognizes the duplicate references and interprets it as a moved element on next write, resulting in empty containers

I've moved to sequential id generation and put in a copy when parsing contained xml — that should be a little safer.

Connects to https://github.com/archivematica/Issues/issues/442.