### PR TITLE
Ensure FILEID is updated in all places

### DIFF
--- a/metsrw/__init__.py
+++ b/metsrw/__init__.py
@@ -43,7 +43,7 @@ from . import plugins
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())
-__version__ = "0.3.9"
+__version__ = "0.3.10"
 
 __all__ = [
     "Agent",

--- a/metsrw/fsentry.py
+++ b/metsrw/fsentry.py
@@ -183,6 +183,7 @@ class FSEntry(DependencyPossessor):
     def from_fptr(cls, label, type_, fptr):
         """Return ``FSEntry`` object."""
         return FSEntry(
+            fileid=fptr.fileid,
             label=label,
             type=type_,
             path=fptr.path,
@@ -197,7 +198,7 @@ class FSEntry(DependencyPossessor):
         return "{s.type}: {s.path}".format(s=self)
 
     def __repr__(self):
-        return "FSEntry(type={s.type!r}, path={s.path!r}, use={s.use!r}, label={s.label!r}, file_uuid={s.file_uuid!r}, checksum={s.checksum!r}, checksumtype={s.checksumtype!r})".format(
+        return "FSEntry(type={s.type!r}, path={s.path!r}, use={s.use!r}, label={s.label!r}, file_uuid={s.file_uuid!r}, checksum={s.checksum!r}, checksumtype={s.checksumtype!r}, fileid={s._fileid!r})".format(
             s=self
         )
 

--- a/metsrw/mets.py
+++ b/metsrw/mets.py
@@ -22,7 +22,7 @@ LOGGER = logging.getLogger(__name__)
 
 AIP_ENTRY_TYPE = "archival information package"
 FPtr = namedtuple(
-    "FPtr", "file_uuid derived_from use path amdids checksum checksumtype"
+    "FPtr", "file_uuid derived_from use path amdids checksum checksumtype fileid"
 )
 
 
@@ -455,7 +455,9 @@ class METSDocument(object):
         group_uuid = file_elem.get("GROUPID", "").replace(utils.GROUP_ID_PREFIX, "", 1)
         if group_uuid != file_uuid:
             derived_from = group_uuid  # Use group_uuid as placeholder
-        return FPtr(file_uuid, derived_from, use, path, amdids, checksum, checksumtype)
+        return FPtr(
+            file_uuid, derived_from, use, path, amdids, checksum, checksumtype, file_id
+        )
 
     @staticmethod
     def _add_dmdsecs_to_fs_entry(elem, fs_entry, tree):

--- a/tests/test_mets.py
+++ b/tests/test_mets.py
@@ -323,6 +323,7 @@ class TestMETSDocument(TestCase):
         # Test the integrity of the ``FPtr`` object returned.
         fptr = mw._analyze_fptr(fptr_elem, tree, "directory")
         assert fptr == metsrw.mets.FPtr(
+            fileid="AM68.csv-fc0e52ca-a688-41c0-a10b-c1d36e21e804",
             file_uuid="fc0e52ca-a688-41c0-a10b-c1d36e21e804",
             derived_from=None,
             use="original",


### PR DESCRIPTION
Custom file ids must be updated across the code. When a METS file is
being updated, as an example, the existing FILEID should be read and
passed back into the FSEntry constructor as required. The FSEntry
__repr__ method has been updated to provide more comprehensive class
debugging information when called.

Required by https://github.com/artefactual/archivematica-storage-service/pull/473

**NB.** Will become `0.3.10` once reviewed, and I will rebase the three commits into a single feature commit. 

