### PR TITLE
Provide mechanism to check distribution config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,10 @@ package-source:
 package-wheel: package-deps
 	python setup.py bdist_wheel --universal
 
-package-upload: package-deps package-source package-wheel
+package-check: package-source package-wheel     ## Check the distribution is valid
+	twine check dist/*
+
+package-upload: package-deps package-check
 	twine upload dist/* --repository-url https://upload.pypi.org/legacy/
 
 package: package-upload

--- a/metsrw/__init__.py
+++ b/metsrw/__init__.py
@@ -43,7 +43,7 @@ from . import plugins
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())
-__version__ = "0.3.11"
+__version__ = "0.3.12"
 
 __all__ = [
     "Agent",

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     version=find_version("metsrw", "__init__.py"),
     description="Library for dealing with METS files.",
     long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/artefactual-labs/mets-reader-writer/",
     author="Artefactual",
     author_email="info@artefactual.com",


### PR DESCRIPTION
Adds a package-check command to make sure the package description for pypi is valid. 

Both new combinations of `make` recipe work as anticipated:
```
twine check dist/*
Checking distribution dist/metsrw-0.3.12-py2.py3-none-any.whl: Passed
Checking distribution dist/metsrw-0.3.12.tar.gz: Passed
twine upload dist/* --repository-url https://upload.pypi.org/legacy/
Enter your username:
```
Connected to archivematica/issues#875