### PR TITLE
premisrw: support datetime values

### DIFF
--- a/metsrw/__init__.py
+++ b/metsrw/__init__.py
@@ -43,7 +43,7 @@ from . import plugins
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())
-__version__ = "0.3.17"
+__version__ = "0.3.18"
 
 __all__ = [
     "Agent",

--- a/metsrw/plugins/premisrw/premis.py
+++ b/metsrw/plugins/premisrw/premis.py
@@ -612,6 +612,8 @@ def _data_to_lxml_el(data, ns, nsmap, element_maker=None, snake=True):
             args.append(element)
         elif isinstance(element, etree._Element):
             args.append(element)
+        elif isinstance(element, datetime):
+            args.append(element.isoformat())
         else:
             args.append(six.binary_type(element))
     ret = func(*args)

--- a/tests/plugins/premisrw/test_premis.py
+++ b/tests/plugins/premisrw/test_premis.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime
 from unittest import TestCase
 
 import pytest
@@ -81,6 +82,35 @@ class TestPREMIS(TestCase):
         lxml_el = premis_obj.serialize()
         data = premisrw.premis_to_data(lxml_el)
         assert data == c.EX_COMPR_EVT
+
+    def test_premis_event_cls_datetime(self):
+        """Tests that ``datetime`` is an accepted value and is converted into
+        text using ``isoformat()``.
+        """
+        event_date_time = datetime(2015, 1, 1, 12, 30, 59)
+        premis_obj = premisrw.PREMISEvent(
+            data=(
+                "event",
+                premisrw.PREMIS_META,
+                (
+                    "event_identifier",
+                    ("event_identifier_type", "UUID"),
+                    ("event_identifier_value", "647aef15-dba7-4114-8ff0-d0b04af0c604"),
+                ),
+                ("event_type", "encription"),
+                ("event_date_time", event_date_time),
+                ("event_detail", "event detail"),
+            )
+        )
+
+        lxml_el = premis_obj.serialize()
+
+        assert (
+            lxml_el.find(
+                ".//premis:eventDateTime", namespaces=metsrw.utils.NAMESPACES
+            ).text
+            == event_date_time.isoformat()
+        )
 
     def test_premis_event_cls_kwargs(self):
         """You should be able to pass sanely-named kwargs to ``PREMISEvent`` on


### PR DESCRIPTION
This avoids the following error in Python 3 when using datetime values:

    TypeError: cannot convert 'datetime.datetime' object to bytes
 
Connects to https://github.com/archivematica/Issues/issues/808.