### PR TITLE
Add namespaces to PREMIS plugin to prevent ValueError: Invalid tag name on serialization

### DIFF
--- a/metsrw/__init__.py
+++ b/metsrw/__init__.py
@@ -44,7 +44,7 @@ from . import plugins
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())
-__version__ = "0.3.21"
+__version__ = "0.3.22"
 
 __all__ = [
     "Agent",

--- a/metsrw/plugins/premisrw/utils.py
+++ b/metsrw/plugins/premisrw/utils.py
@@ -3,12 +3,22 @@
 
 XSI_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance"
 
+TOOL_NAMESPACES = {
+    "xlink": "http://www.w3.org/1999/xlink",
+    "fits": "http://hul.harvard.edu/ois/xml/ns/fits/fits_output",
+    "MediaInfo": "https://mediaarea.net/mediainfo",
+}
+
 # PREMIS v. 2.1
 PREMIS_2_1_VERSION = "2.1"
 PREMIS_2_1_NAMESPACE = "info:lc/xmlns/premis-v1"
 PREMIS_2_1_XSD = "http://www.loc.gov/standards/premis/v2/premis-v2-1.xsd"
 PREMIS_2_1_SCHEMA_LOCATION = "{} {}".format(PREMIS_2_1_NAMESPACE, PREMIS_2_1_XSD)
-PREMIS_2_1_NAMESPACES = {"premis": PREMIS_2_1_NAMESPACE, "xsi": XSI_NAMESPACE}
+PREMIS_2_1_NAMESPACES = {
+    "premis": PREMIS_2_1_NAMESPACE,
+    "xsi": XSI_NAMESPACE,
+}
+PREMIS_2_1_NAMESPACES.update(TOOL_NAMESPACES)
 PREMIS_2_1_META = {
     "xsi:schema_location": PREMIS_2_1_SCHEMA_LOCATION,
     "version": PREMIS_2_1_VERSION,
@@ -19,7 +29,11 @@ PREMIS_2_2_VERSION = "2.2"
 PREMIS_2_2_NAMESPACE = "info:lc/xmlns/premis-v2"
 PREMIS_2_2_XSD = "http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd"
 PREMIS_2_2_SCHEMA_LOCATION = "{} {}".format(PREMIS_2_2_NAMESPACE, PREMIS_2_2_XSD)
-PREMIS_2_2_NAMESPACES = {"premis": PREMIS_2_2_NAMESPACE, "xsi": XSI_NAMESPACE}
+PREMIS_2_2_NAMESPACES = {
+    "premis": PREMIS_2_2_NAMESPACE,
+    "xsi": XSI_NAMESPACE,
+}
+PREMIS_2_2_NAMESPACES.update(TOOL_NAMESPACES)
 PREMIS_2_2_META = {
     "xsi:schema_location": PREMIS_2_2_SCHEMA_LOCATION,
     "version": PREMIS_2_2_VERSION,
@@ -30,16 +44,29 @@ PREMIS_3_0_VERSION = "3.0"
 PREMIS_3_0_NAMESPACE = "http://www.loc.gov/premis/v3"
 PREMIS_3_0_XSD = "http://www.loc.gov/standards/premis/v3/premis.xsd"
 PREMIS_3_0_SCHEMA_LOCATION = "{} {}".format(PREMIS_3_0_NAMESPACE, PREMIS_3_0_XSD)
-PREMIS_3_0_NAMESPACES = {"premis": PREMIS_3_0_NAMESPACE, "xsi": XSI_NAMESPACE}
+PREMIS_3_0_NAMESPACES = {
+    "premis": PREMIS_3_0_NAMESPACE,
+    "xsi": XSI_NAMESPACE,
+}
+PREMIS_3_0_NAMESPACES.update(TOOL_NAMESPACES)
 PREMIS_3_0_META = {
     "xsi:schema_location": PREMIS_3_0_SCHEMA_LOCATION,
     "version": PREMIS_3_0_VERSION,
 }
 
 PREMIS_VERSIONS_MAP = {
-    PREMIS_2_1_VERSION: {"namespaces": PREMIS_2_2_NAMESPACES, "meta": PREMIS_2_1_META},
-    PREMIS_2_2_VERSION: {"namespaces": PREMIS_2_2_NAMESPACES, "meta": PREMIS_2_2_META},
-    PREMIS_3_0_VERSION: {"namespaces": PREMIS_3_0_NAMESPACES, "meta": PREMIS_3_0_META},
+    PREMIS_2_1_VERSION: {
+        "namespaces": PREMIS_2_2_NAMESPACES,
+        "meta": PREMIS_2_1_META,
+    },
+    PREMIS_2_2_VERSION: {
+        "namespaces": PREMIS_2_2_NAMESPACES,
+        "meta": PREMIS_2_2_META,
+    },
+    PREMIS_3_0_VERSION: {
+        "namespaces": PREMIS_3_0_NAMESPACES,
+        "meta": PREMIS_3_0_META,
+    },
 }
 
 # Treat PREMIS v. 2.2 as the default (for now).


### PR DESCRIPTION
Connected to https://github.com/artefactual-labs/mets-reader-writer/issues/94

This PR adds characterization tool namespaces to the PREMIS plugin's namespaces dictionaries to prevent serialization errors when serializing `PREMISObject`s that contain characterization tool output to XML.

This will enable adding raw PREMIS Object XML to the AIPscan database for files with characterization tool output.

Note that linting is currently failing because of the version of Black we are using. See: https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click. Upgrading Black to 22.3.0 also causes linting failures, as the newer version of Black wants us to drop explicit unicode strings (e.g. `u"something"`). I think that might be better handled in a separate PR.