### PR TITLE
Ignore XML comments on PREMIS elements parsing

### DIFF
--- a/fixtures/complete_mets.xml
+++ b/fixtures/complete_mets.xml
@@ -51,7 +51,10 @@
                   <formatRegistryKey>fmt/43</formatRegistryKey>
                 </formatRegistry>
               </format>
-              <objectCharacteristicsExtension>Stuff</objectCharacteristicsExtension>
+              <objectCharacteristicsExtension>
+                <!-- Stuff comment -->
+                <stuff>Stuff</stuff>
+              </objectCharacteristicsExtension>
             </objectCharacteristics>
             <originalName>%transferDirectory%objects/Landing zone.jpg</originalName>
             <relationship>

--- a/metsrw/plugins/premisrw/premis.py
+++ b/metsrw/plugins/premisrw/premis.py
@@ -680,6 +680,9 @@ def _get_el_attributes(lxml_el, ns=None, nsmap=None):
 
 def _lxml_el_to_data(lxml_el, ns, nsmap, snake=True):
     """Convert an ``lxml._Element`` instance to a Python tuple."""
+    # Ignore comments. They add no value to the data structure.
+    if isinstance(lxml_el, etree._Comment):
+        return ()
     tag_name = _to_colon_ns(lxml_el.tag, default_ns=ns, nsmap=nsmap)
     ret = [tag_name]
     attributes = _get_el_attributes(lxml_el, ns=ns, nsmap=nsmap)


### PR DESCRIPTION
XML comments break parsing of `PREMIS:OBJECT` elements in the METS because `lxml` doesn't create `etree.Element` objects for them.

This just ignores them since they don't add any value to the resulting tuples.

Connected to https://github.com/archivematica/Issues/issues/1277