### PR TITLE
Lint Markdown files

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,10 @@
+{
+  "default": true,
+  "MD010": {
+    "code_blocks": false
+  },
+  "MD013": {
+    "code_blocks": false,
+    "tables": false
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,15 @@ repos:
     additional_dependencies:
     - flake8-bugbear==23.9.16
     - flake8-comprehensions==3.14.0
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.37.0
+  hooks:
+  - id: markdownlint
+- repo: https://github.com/thlorenz/doctoc
+  rev: v2.2.0
+  hooks:
+  - id: doctoc
+    files: |
+      (?x)^(
+        CONTRIBUTING\.md
+      )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,71 +1,93 @@
 # Contributing
 
 Thank you for considering a contribution to the METS Reader/Writer!
-This document outlines the change submission process for metsrw, along with our standards for new code contributions.
-Following these guidelines helps us assess your changes faster and makes it easier for us to merge you submission!
+This document outlines the change submission process for metsrw, along with our
+standards for new code contributions. Following these guidelines helps us assess
+your changes faster and makes it easier for us to merge you submission!
 
-There are many ways to contribute: providing feedback on the [design & API](https://github.com/artefactual-labs/mets-reader-writer/wiki), submitting bug reports, or writing code which can be incorporated into metsrw itself.
+There are many ways to contribute: providing feedback on the [design & API](https://github.com/artefactual-labs/mets-reader-writer/wiki),
+submitting bug reports, or writing code which can be incorporated into metsrw
+itself.
+
+## Table of contents
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Contributing](#contributing)
-  - [Submitting bugs](#submitting-bugs)
-  - [Contribution standards](#contribution-standards)
-  - [Contributor's Agreement](#contributors-agreement)
-    - [Why do I have to sign a Contributor's Agreement?](#why-do-i-have-to-sign-a-contributors-agreement)
-    - [How do I send in an agreement?](#how-do-i-send-in-an-agreement)
+- [Submitting bugs](#submitting-bugs)
+- [Contribution standards](#contribution-standards)
+- [Contributor's Agreement](#contributors-agreement)
+  - [Why do I have to sign a Contributor's Agreement?](#why-do-i-have-to-sign-a-contributors-agreement)
+  - [How do I send in an agreement?](#how-do-i-send-in-an-agreement)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Submitting bugs
 
 If you find a security vulnerability, do NOT open an issue.
-Email security@artefactual.com instead.
+Email <security@artefactual.com> instead.
 
-All issues about Archivematica or related libraries should be filed in the [Archivematica Issues repository](https://github.com/archivematica/Issues/issues).
+All issues about Archivematica or related libraries should be filed in the
+[Archivematica Issues repository](https://github.com/archivematica/Issues/issues).
 
 You can also post to the [Archivematica user forum](https://groups.google.com/forum/#!forum/archivematica).
-A post to the mailing list is always welcome, especially if you're unsure if it's a bug or a local problem!
+A post to the mailing list is always welcome, especially if you're unsure if
+it's a bug or a local problem!
 
 Useful questions to answer if you're having problems include:
 
-* What version of metsrw are you using?
-* How was it installed?
-* What did you do to cause this bug to happen?
-* What did you expect to happen?
-* What did you see instead?
-* Can you reproduce this reliably?
+- What version of metsrw are you using?
+- How was it installed?
+- What did you do to cause this bug to happen?
+- What did you expect to happen?
+- What did you see instead?
+- Can you reproduce this reliably?
 
 ## Contribution standards
 
-For more information on contribution guidelines and standards, see the CONTRIBUTING.md in the [Archivematica project](https://github.com/artefactual/archivematica).
+For more information on contribution guidelines and standards, see the
+CONTRIBUTING.md in the [Archivematica project](https://github.com/artefactual/archivematica).
 
 ## Contributor's Agreement
 
-In order for the Archivematica development team to accept any patches or code commits, contributors must first sign this [Contributor's Agreement](https://wiki.archivematica.org/images/e/e6/Archivematica-CLA-firstname-lastname-YYYY.pdf).
-The Archivematica contributor's agreement is based almost verbatim on the [Apache Foundation](http://apache.org )'s individual [contributor license](http://www.apache.org/licenses/icla.txt).
+In order for the Archivematica development team to accept any patches or code
+commits, contributors must first sign this [Contributor's Agreement](https://wiki.archivematica.org/images/e/e6/Archivematica-CLA-firstname-lastname-YYYY.pdf).
+The Archivematica contributor's agreement is based almost verbatim on the
+[Apache Foundation](http://apache.org )'s individual [contributor license](http://www.apache.org/licenses/icla.txt).
 
-If you have any questions or concerns about the Contributor's Agreement, please email us at agreement@artefactual.com to discuss them.
+If you have any questions or concerns about the Contributor's Agreement, please
+email us at <agreement@artefactual.com> to discuss them.
 
 ### Why do I have to sign a Contributor's Agreement?
 
-One of the key challenges for open source software is to support a collaborative development environment while protecting the rights of contributors and users over the long-term.
-Unifying Archivematica copyrights through contributor agreements is the best way to protect the availability and sustainability of Archivematica over the long-term as free and open-source software.
-In all cases, contributors who sign the Contributor's Agreement retain full rights to use their original contributions for any other purpose outside of Archivematica, while enabling Artefactual Systems, any successor organization which may eventually take over responsibility for Archivematica, and the wider Archivematica community to benefit from their collaboration and contributions in this open source project.
+One of the key challenges for open source software is to support a collaborative
+development environment while protecting the rights of contributors and users
+over the long-term.
+Unifying Archivematica copyrights through contributor agreements is the best way
+to protect the availability and sustainability of Archivematica over the
+long-term as free and open-source software.
+In all cases, contributors who sign the Contributor's Agreement retain full
+rights to use their original contributions for any other purpose outside of
+Archivematica, while enabling Artefactual Systems, any successor organization
+which may eventually take over responsibility for Archivematica, and the wider
+Archivematica community to benefit from their collaboration and contributions in
+this open source project.
 
-[Artefactual Systems](http://artefactual.com) has made the decision and has a proven track record of making our intellectual property available to the community at large.
-By standardizing contributions on these agreements the Archivematica intellectual property position does not become too complicated.
-This ensures our resources are devoted to making our project the best they can be, rather than fighting legal battles over contributions.
+[Artefactual Systems](http://artefactual.com) has made the decision and has a
+proven track record of making our intellectual property available to the
+community at large.
+By standardizing contributions on these agreements the Archivematica
+intellectual property position does not become too complicated.
+This ensures our resources are devoted to making our project the best they can
+be, rather than fighting legal battles over contributions.
 
 ### How do I send in an agreement?
 
-Please print out, read, sign, and scan the [contributor agreement](https://wiki.archivematica.org/images/e/e6/Archivematica-CLA-firstname-lastname-YYYY.pdf) and email it to agreement@artefactual.com
+Please print out, read, sign, and scan the [contributor agreement](https://wiki.archivematica.org/images/e/e6/Archivematica-CLA-firstname-lastname-YYYY.pdf)
+and email it to <agreement@artefactual.com>
 Alternatively, you may send an original signed agreement to:
 
     Artefactual Systems Inc.
     201 - 301 Sixth Street
     New Westminster BC  V3L 3A7
     Canada
-

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
-[![PyPI version](https://badge.fury.io/py/metsrw.svg)](https://badge.fury.io/py/metsrw) [![codecov](https://codecov.io/gh/artefactual-labs/mets-reader-writer/branch/master/graph/badge.svg?token=1cXYbNlgJr)](https://codecov.io/gh/artefactual-labs/mets-reader-writer)
-
 # METS Reader & Writer
 
 By [Artefactual](https://www.artefactual.com/)
 
+[![PyPI version](https://badge.fury.io/py/metsrw.svg)](https://badge.fury.io/py/metsrw)
+[![GitHub CI](https://github.com/artefactual-labs/mets-reader-writer/actions/workflows/test.yml/badge.svg)](https://github.com/artefactual-labs/mets-reader-writer/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/artefactual-labs/mets-reader-writer/branch/master/graph/badge.svg?token=1cXYbNlgJr)](https://codecov.io/gh/artefactual-labs/mets-reader-writer)
+
 METSRW is a library to help with parsing and creating METS files.
 It provides an API, and abstracts away the actual creation of the XML.
-METSRW was initially created for use in [Archivematica](https://github.com/artefactual/archivematica/) and is managed as part of that project.
+METSRW was initially created for use in [Archivematica](https://github.com/artefactual/archivematica/)
+and is managed as part of that project.
 
-You are free to copy, modify, and distribute metsrw with attribution under the terms of the AGPL license.
-See the [LICENSE](LICENSE) file for details.
-
+You are free to copy, modify, and distribute metsrw with attribution under the
+terms of the AGPL license. See the [LICENSE](LICENSE) file for details.
 
 ## Installation & Dependencies
 
@@ -36,7 +38,6 @@ Read a METS file
 Create a new METS file
 
     mets = metsrw.METSDocument()
-
 
 ## Contributing
 


### PR DESCRIPTION
This adds `markdownlint` and `doctoc` to `pre-commit` for linting the main markdown files in the repository.