### PR TITLE
Add Read the Docs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true
+sphinx:
+  configuration: docs/conf.py
+python:
+  install:
+    - requirements: requirements-dev.txt


### PR DESCRIPTION
The builds of the `mets-reader-writer` project in Read the Docs have been [failing since September 2023](https://readthedocs.org/projects/mets-reader-writer/builds/) when Read the Docs [made their configuration file mandatory](https://blog.readthedocs.com/migrate-configuration-v2/).

This adds the `.readthedocs.yaml` configuration file based on the [sample configuration](https://docs.readthedocs.io/en/latest/config-file/v2.html#configuration-file-v2-readthedocs-yaml) with [support for git tags](https://docs.readthedocs.io/en/latest/build-customization.html#unshallow-git-clone) and the [Python development requirements](https://docs.readthedocs.io/en/latest/config-file/v2.html#requirements-file).