### PR TITLE
Use Read The Docs Sphinx theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,12 @@ from metsrw import __version__
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode", "sphinx.ext.doctest"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.doctest",
+    "sphinx_rtd_theme",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -98,7 +103,7 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "default"
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
   "pip-tools",
   "pytest-cov",
   "pytest",
+  "sphinx-rtd-theme",
   "sphinx==7.1.2",
   "sphinxcontrib-applehelp==1.0.4",
   "sphinxcontrib-devhelp==1.0.2",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,9 @@ coverage[toml]==7.4.0
     #   metsrw (pyproject.toml)
     #   pytest-cov
 docutils==0.20.1
-    # via sphinx
+    # via
+    #   sphinx
+    #   sphinx-rtd-theme
 exceptiongroup==1.2.0
     # via pytest
 idna==3.6
@@ -40,7 +42,7 @@ jinja2==3.1.3
     # via sphinx
 lxml==5.1.0
     # via metsrw (pyproject.toml)
-markupsafe==2.1.3
+markupsafe==2.1.4
     # via jinja2
 packaging==23.2
     # via
@@ -66,6 +68,11 @@ requests==2.31.0
 snowballstemmer==2.2.0
     # via sphinx
 sphinx==7.1.2
+    # via
+    #   metsrw (pyproject.toml)
+    #   sphinx-rtd-theme
+    #   sphinxcontrib-jquery
+sphinx-rtd-theme==2.0.0
     # via metsrw (pyproject.toml)
 sphinxcontrib-applehelp==1.0.4
     # via
@@ -79,6 +86,8 @@ sphinxcontrib-htmlhelp==2.0.1
     # via
     #   metsrw (pyproject.toml)
     #   sphinx
+sphinxcontrib-jquery==4.1
+    # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==1.0.3


### PR DESCRIPTION
Now that Read The Docs builds have been fixed it seems the current theme doesn't match the one in previous builds.

Current theme:
![Screenshot 2024-01-21 at 22-21-36 METS Reader   Writer — METS Reader   Writer 0 5 0 documentation](https://github.com/artefactual-labs/mets-reader-writer/assets/560781/ebfeaea4-f155-40c5-bd7b-90dd321ed78d)

Previous theme:

![Screenshot 2024-01-21 at 22-22-08 METS Reader   Writer — METS Reader   Writer 0 3 15 documentation](https://github.com/artefactual-labs/mets-reader-writer/assets/560781/1348e6f5-b8dd-475d-9095-c14758bb2bc2)

This PR sets [the Read The Docs theme](https://sphinx-rtd-theme.readthedocs.io/en/stable/index.html) explicitly in the Sphinx configuration to address the problem.